### PR TITLE
test: Add tests

### DIFF
--- a/gleam.toml
+++ b/gleam.toml
@@ -17,3 +17,4 @@ cowboy = "~> 2.0"
 
 [dev-dependencies]
 gleeunit = "~> 0.1"
+gleam_hackney = "~> 0.2"

--- a/manifest.toml
+++ b/manifest.toml
@@ -2,18 +2,28 @@
 # You typically do not need to edit this file
 
 packages = [
-  { name = "cowboy", version = "2.9.0", build_tools = ["make", "rebar3"], requirements = ["cowlib", "ranch"], otp_app = "cowboy", source = "hex", outer_checksum = "2C729F934B4E1AA149AFF882F57C6372C15399A20D54F65C8D67BEF583021BDE" },
+  { name = "certifi", version = "2.9.0", build_tools = ["rebar3"], requirements = [], otp_app = "certifi", source = "hex", outer_checksum = "266DA46BDB06D6C6D35FDE799BCB28D36D985D424AD7C08B5BB48F5B5CDD4641" },
+  { name = "cowboy", version = "2.9.0", build_tools = ["make", "rebar3"], requirements = ["ranch", "cowlib"], otp_app = "cowboy", source = "hex", outer_checksum = "2C729F934B4E1AA149AFF882F57C6372C15399A20D54F65C8D67BEF583021BDE" },
   { name = "cowlib", version = "2.11.0", build_tools = ["make", "rebar3"], requirements = [], otp_app = "cowlib", source = "hex", outer_checksum = "2B3E9DA0B21C4565751A6D4901C20D1B4CC25CBB7FD50D91D2AB6DD287BC86A9" },
   { name = "gleam_erlang", version = "0.9.1", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_erlang", source = "hex", outer_checksum = "5AB10E3E0AF2956A035559F70944F6DEB7AFD6A8295171E5BBEB6831AECA3A47" },
+  { name = "gleam_hackney", version = "0.2.0", build_tools = ["gleam"], requirements = ["gleam_http", "gleam_stdlib", "hackney"], otp_app = "gleam_hackney", source = "hex", outer_checksum = "560B3577E24F4105BB0EFEC24BB97E7CD8F1F4C8AA62A3AAC8FA6226F35DE8E4" },
   { name = "gleam_http", version = "3.0.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_http", source = "hex", outer_checksum = "FB65B42C7AF4C14F1DC0AD9A3ABCE50E9486D3F8D0A42C9E52A2B8BD651739DF" },
-  { name = "gleam_otp", version = "0.3.1", build_tools = ["gleam"], requirements = ["gleam_stdlib", "gleam_erlang"], otp_app = "gleam_otp", source = "hex", outer_checksum = "9F779074D0CD3760E280E24247BA17FC673D654234D56B3A8F187DC8FDE299B7" },
+  { name = "gleam_otp", version = "0.3.1", build_tools = ["gleam"], requirements = ["gleam_erlang", "gleam_stdlib"], otp_app = "gleam_otp", source = "hex", outer_checksum = "9F779074D0CD3760E280E24247BA17FC673D654234D56B3A8F187DC8FDE299B7" },
   { name = "gleam_stdlib", version = "0.19.3", build_tools = ["gleam"], requirements = [], otp_app = "gleam_stdlib", source = "hex", outer_checksum = "CA579C2FF0621E93FF6EFEF61BAFFCF0505732BA073F616E28878042F1A1F401" },
   { name = "gleeunit", version = "0.6.1", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleeunit", source = "hex", outer_checksum = "5BF486C3E135B7F5ED8C054925FC48E5B2C79016A39F416FD8CF2E860520EE55" },
+  { name = "hackney", version = "1.18.1", build_tools = ["rebar3"], requirements = ["metrics", "mimerl", "parse_trans", "ssl_verify_fun", "unicode_util_compat", "certifi", "idna"], otp_app = "hackney", source = "hex", outer_checksum = "A4ECDAFF44297E9B5894AE499E9A070EA1888C84AFDD1FD9B7B2BC384950128E" },
+  { name = "idna", version = "6.1.1", build_tools = ["rebar3"], requirements = ["unicode_util_compat"], otp_app = "idna", source = "hex", outer_checksum = "92376EB7894412ED19AC475E4A86F7B413C1B9FBB5BD16DCCD57934157944CEA" },
+  { name = "metrics", version = "1.0.1", build_tools = ["rebar3"], requirements = [], otp_app = "metrics", source = "hex", outer_checksum = "69B09ADDDC4F74A40716AE54D140F93BEB0FB8978D8636EADED0C31B6F099F16" },
+  { name = "mimerl", version = "1.2.0", build_tools = ["rebar3"], requirements = [], otp_app = "mimerl", source = "hex", outer_checksum = "F278585650AA581986264638EBF698F8BB19DF297F66AD91B18910DFC6E19323" },
+  { name = "parse_trans", version = "3.3.1", build_tools = ["rebar3"], requirements = [], otp_app = "parse_trans", source = "hex", outer_checksum = "07CD9577885F56362D414E8C4C4E6BDF10D43A8767ABB92D24CBE8B24C54888B" },
   { name = "ranch", version = "1.8.0", build_tools = ["make", "rebar3"], requirements = [], otp_app = "ranch", source = "hex", outer_checksum = "49FBCFD3682FAB1F5D109351B61257676DA1A2FDBE295904176D5E521A2DDFE5" },
+  { name = "ssl_verify_fun", version = "1.1.6", build_tools = ["mix", "rebar3", "make"], requirements = [], otp_app = "ssl_verify_fun", source = "hex", outer_checksum = "BDB0D2471F453C88FF3908E7686F86F9BE327D065CC1EC16FA4540197EA04680" },
+  { name = "unicode_util_compat", version = "0.7.0", build_tools = ["rebar3"], requirements = [], otp_app = "unicode_util_compat", source = "hex", outer_checksum = "25EEE6D67DF61960CF6A794239566599B09E17E668D3700247BC498638152521" },
 ]
 
 [requirements]
 cowboy = "~> 2.0"
+gleam_hackney = "~> 0.2"
 gleam_http = "~> 3.0"
 gleam_otp = "~> 0.3"
 gleam_stdlib = "~> 0.18"

--- a/test/gleam/http/cowboy_test.gleam
+++ b/test/gleam/http/cowboy_test.gleam
@@ -1,0 +1,90 @@
+import gleam/erlang
+import gleam/http/cowboy
+import gleam/bit_builder.{BitBuilder}
+import gleam/http.{Get, Head, Post}
+import gleam/http/request.{Request}
+import gleam/http/response.{Response}
+import gleam/hackney
+
+pub fn echo_service(request: Request(BitString)) -> Response(BitBuilder) {
+  let body = case request.body {
+    <<>> -> bit_builder.from_string("Default body")
+    x -> bit_builder.from_bit_string(x)
+  }
+  response.new(200)
+  |> response.prepend_header("made-with", "Gleam")
+  |> response.set_body(body)
+}
+
+pub fn request_test() {
+  // TODO: Assign these ports on random free ones aviable
+  // TODO: Shut down server after test?
+  let port = 3078
+  assert Ok(_) = cowboy.start(echo_service, on_port: port)
+
+  let req =
+    request.new()
+    |> request.set_method(Get)
+    |> request.set_host("0.0.0.0")
+    |> request.set_scheme(http.Http)
+    |> request.set_port(port)
+
+  assert Ok(resp) = hackney.send(req)
+  assert 200 = resp.status
+  assert Ok("Gleam") = response.get_header(resp, "made-with")
+  assert "Default body" = resp.body
+}
+
+pub fn get_request_does_not_discard_body_test() {
+  let port = 3079
+  assert Ok(_) = cowboy.start(echo_service, on_port: port)
+
+  let req =
+    request.new()
+    |> request.set_method(Get)
+    |> request.set_host("0.0.0.0")
+    |> request.set_scheme(http.Http)
+    |> request.set_port(port)
+    |> request.set_body("This does NOT get dropped")
+
+  assert Ok(resp) = hackney.send(req)
+  assert 200 = resp.status
+  assert Ok("Gleam") = response.get_header(resp, "made-with")
+  assert "This does NOT get dropped" = resp.body
+}
+
+pub fn head_request_discards_body_test() {
+  let port = 3080
+  assert Ok(_) = cowboy.start(echo_service, on_port: port)
+
+  let req =
+    request.new()
+    |> request.set_method(Head)
+    |> request.set_host("0.0.0.0")
+    |> request.set_scheme(http.Http)
+    |> request.set_port(port)
+    |> request.set_body("This gets dropped")
+
+  assert Ok(resp) = hackney.send(req)
+  assert 200 = resp.status
+  assert Ok("Gleam") = response.get_header(resp, "made-with")
+  assert "" = resp.body
+}
+
+pub fn body_is_echoed_on_post_test() {
+  let port = 3081
+  assert Ok(_) = cowboy.start(echo_service, on_port: port)
+
+  let req =
+    request.new()
+    |> request.set_method(Post)
+    |> request.set_host("0.0.0.0")
+    |> request.set_scheme(http.Http)
+    |> request.set_port(port)
+    |> request.set_body("Ping")
+
+  assert Ok(resp) = hackney.send(req)
+  assert 200 = resp.status
+  assert Ok("Gleam") = response.get_header(resp, "made-with")
+  assert "Ping" = resp.body
+}


### PR DESCRIPTION
These were mostly copy/pasted from the `gleam_httpc` test cases. Because `httpc` still uses `gleam_http` 2.0 APIs (for now) I've added `gleam_hackney` as a dev HTTP client.

Closes #1 