### PR TITLE
Update `gleam/process` import in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ gleam add gleam_cowboy
 ```
 
 ```gleam
-import gleam/process
+import gleam/erlang/process
 import gleam/http/cowboy
 import gleam/http/response.{Response}
 import gleam/http/request.{Request}


### PR DESCRIPTION
This PR updates the `gleam/process` import in the example in the README to work with the latest version of Gleam (v0.29.0).
