### PR TITLE
Add support for gleam v1.0.0

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,7 +14,7 @@ jobs:
       - uses: erlef/setup-beam@v1
         with:
           otp-version: "26.1"
-          gleam-version: "0.32.0"
+          gleam-version: "1.0.0"
           rebar3-version: "3"
       - run: gleam format --check src test
       - run: gleam test

--- a/README.md
+++ b/README.md
@@ -15,14 +15,14 @@ gleam add gleam_cowboy
 ```gleam
 import gleam/erlang/process
 import gleam/http/cowboy
-import gleam/http/response.{Response}
-import gleam/http/request.{Request}
-import gleam/bit_builder.{BitBuilder}
+import gleam/http/response.{type Response}
+import gleam/http/request.{type Request}
+import gleam/bytes_builder.{type BytesBuilder}
 
 // Define a HTTP service
 //
-pub fn my_service(request: Request(t)) -> Response(BitBuilder) {
-  let body = bit_builder.from_string("Hello, world!")
+pub fn my_service(request: Request(t)) -> Response(BytesBuilder) {
+  let body = bytes_builder.from_string("Hello, world!")
 
   response.new(200)
   |> response.prepend_header("made-with", "Gleam")

--- a/gleam.toml
+++ b/gleam.toml
@@ -14,7 +14,7 @@ links = [
 gleam_stdlib = "~> 0.31"
 gleam_http = "~> 3.0"
 gleam_otp = "~> 0.7"
-cowboy = "~> 2.10.0"
+cowboy = "~> 2.0"
 gleam_erlang = "~> 0.22"
 
 [dev-dependencies]

--- a/gleam.toml
+++ b/gleam.toml
@@ -14,7 +14,7 @@ links = [
 gleam_stdlib = "~> 0.31"
 gleam_http = "~> 3.0"
 gleam_otp = "~> 0.7"
-cowboy = "~> 2.0"
+cowboy = "~> 2.5"
 gleam_erlang = "~> 0.22"
 
 [dev-dependencies]

--- a/gleam.toml
+++ b/gleam.toml
@@ -1,8 +1,8 @@
 name = "gleam_cowboy"
-version = "0.6.0"
+version = "0.7.0"
 licences = ["Apache-2.0"]
 description = "Run Gleam HTTP services with the Cowboy web server"
-gleam = ">= 0.32.0"
+gleam = ">= 1.0.0"
 
 repository = { type = "github", user = "gleam-lang", repo = "cowboy" }
 links = [
@@ -14,7 +14,7 @@ links = [
 gleam_stdlib = "~> 0.31"
 gleam_http = "~> 3.0"
 gleam_otp = "~> 0.7"
-cowboy = "~> 2.0"
+cowboy = "~> 2.10.0"
 gleam_erlang = "~> 0.22"
 
 [dev-dependencies]

--- a/manifest.toml
+++ b/manifest.toml
@@ -3,8 +3,8 @@
 
 packages = [
   { name = "certifi", version = "2.12.0", build_tools = ["rebar3"], requirements = [], otp_app = "certifi", source = "hex", outer_checksum = "EE68D85DF22E554040CDB4BE100F33873AC6051387BAF6A8F6CE82272340FF1C" },
-  { name = "cowboy", version = "2.10.0", build_tools = ["make", "rebar3"], requirements = ["cowlib", "ranch"], otp_app = "cowboy", source = "hex", outer_checksum = "3AFDCCB7183CC6F143CB14D3CF51FA00E53DB9EC80CDCD525482F5E99BC41D6B" },
-  { name = "cowlib", version = "2.12.1", build_tools = ["make", "rebar3"], requirements = [], otp_app = "cowlib", source = "hex", outer_checksum = "163B73F6367A7341B33C794C4E88E7DBFE6498AC42DCD69EF44C5BC5507C8DB0" },
+  { name = "cowboy", version = "2.12.0", build_tools = ["make", "rebar3"], requirements = ["cowlib", "ranch"], otp_app = "cowboy", source = "hex", outer_checksum = "8A7ABE6D183372CEB21CAA2709BEC928AB2B72E18A3911AA1771639BEF82651E" },
+  { name = "cowlib", version = "2.13.0", build_tools = ["make", "rebar3"], requirements = [], otp_app = "cowlib", source = "hex", outer_checksum = "E1E1284DC3FC030A64B1AD0D8382AE7E99DA46C3246B815318A4B848873800A4" },
   { name = "gleam_erlang", version = "0.24.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_erlang", source = "hex", outer_checksum = "26BDB52E61889F56A291CB34167315780EE4AA20961917314446542C90D1C1A0" },
   { name = "gleam_hackney", version = "1.2.0", build_tools = ["gleam"], requirements = ["gleam_http", "gleam_stdlib", "hackney"], otp_app = "gleam_hackney", source = "hex", outer_checksum = "066B1A55D37DBD61CC72A1C4EDE43C6015B1797FAF3818C16FE476534C7B6505" },
   { name = "gleam_http", version = "3.6.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_http", source = "hex", outer_checksum = "8C07DF9DF8CC7F054C650839A51C30A7D3C26482AC241C899C1CEA86B22DBE51" },
@@ -22,7 +22,7 @@ packages = [
 ]
 
 [requirements]
-cowboy = { version = "~> 2.10.0" }
+cowboy = { version = "~> 2.0" }
 gleam_erlang = { version = "~> 0.22" }
 gleam_hackney = { version = "~> 1.0" }
 gleam_http = { version = "~> 3.0" }

--- a/manifest.toml
+++ b/manifest.toml
@@ -3,15 +3,15 @@
 
 packages = [
   { name = "certifi", version = "2.12.0", build_tools = ["rebar3"], requirements = [], otp_app = "certifi", source = "hex", outer_checksum = "EE68D85DF22E554040CDB4BE100F33873AC6051387BAF6A8F6CE82272340FF1C" },
-  { name = "cowboy", version = "2.10.0", build_tools = ["make", "rebar3"], requirements = ["ranch", "cowlib"], otp_app = "cowboy", source = "hex", outer_checksum = "3AFDCCB7183CC6F143CB14D3CF51FA00E53DB9EC80CDCD525482F5E99BC41D6B" },
+  { name = "cowboy", version = "2.10.0", build_tools = ["make", "rebar3"], requirements = ["cowlib", "ranch"], otp_app = "cowboy", source = "hex", outer_checksum = "3AFDCCB7183CC6F143CB14D3CF51FA00E53DB9EC80CDCD525482F5E99BC41D6B" },
   { name = "cowlib", version = "2.12.1", build_tools = ["make", "rebar3"], requirements = [], otp_app = "cowlib", source = "hex", outer_checksum = "163B73F6367A7341B33C794C4E88E7DBFE6498AC42DCD69EF44C5BC5507C8DB0" },
-  { name = "gleam_erlang", version = "0.23.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_erlang", source = "hex", outer_checksum = "DA7A8E5540948DE10EB01B530869F8FF2FF6CAD8CFDA87626CE6EF63EBBF87CB" },
-  { name = "gleam_hackney", version = "1.1.0", build_tools = ["gleam"], requirements = ["gleam_stdlib", "hackney", "gleam_http"], otp_app = "gleam_hackney", source = "hex", outer_checksum = "CA69AD9061C4A8775A7BD445DE33ECEFD87379AF8E5B028F3DD0216BECA5DD0B" },
-  { name = "gleam_http", version = "3.5.1", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_http", source = "hex", outer_checksum = "0B09AAE8EB547C4F2F2D3F8917A0A4D2EF75DFF0232389332BAFE19DBBFDB92B" },
-  { name = "gleam_otp", version = "0.7.0", build_tools = ["gleam"], requirements = ["gleam_stdlib", "gleam_erlang"], otp_app = "gleam_otp", source = "hex", outer_checksum = "ED7381E90636E18F5697FD7956EECCA635A3B65538DC2BE2D91A38E61DCE8903" },
-  { name = "gleam_stdlib", version = "0.32.0", build_tools = ["gleam"], requirements = [], otp_app = "gleam_stdlib", source = "hex", outer_checksum = "07D64C26D014CF570F8ACADCE602761EA2E74C842D26F2FD49B0D61973D9966F" },
-  { name = "gleeunit", version = "1.0.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleeunit", source = "hex", outer_checksum = "D3682ED8C5F9CAE1C928F2506DE91625588CC752495988CBE0F5653A42A6F334" },
-  { name = "hackney", version = "1.20.1", build_tools = ["rebar3"], requirements = ["mimerl", "certifi", "metrics", "idna", "ssl_verify_fun", "unicode_util_compat", "parse_trans"], otp_app = "hackney", source = "hex", outer_checksum = "FE9094E5F1A2A2C0A7D10918FEE36BFEC0EC2A979994CFF8CFE8058CD9AF38E3" },
+  { name = "gleam_erlang", version = "0.24.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_erlang", source = "hex", outer_checksum = "26BDB52E61889F56A291CB34167315780EE4AA20961917314446542C90D1C1A0" },
+  { name = "gleam_hackney", version = "1.2.0", build_tools = ["gleam"], requirements = ["gleam_http", "gleam_stdlib", "hackney"], otp_app = "gleam_hackney", source = "hex", outer_checksum = "066B1A55D37DBD61CC72A1C4EDE43C6015B1797FAF3818C16FE476534C7B6505" },
+  { name = "gleam_http", version = "3.6.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_http", source = "hex", outer_checksum = "8C07DF9DF8CC7F054C650839A51C30A7D3C26482AC241C899C1CEA86B22DBE51" },
+  { name = "gleam_otp", version = "0.10.0", build_tools = ["gleam"], requirements = ["gleam_erlang", "gleam_stdlib"], otp_app = "gleam_otp", source = "hex", outer_checksum = "0B04FE915ACECE539B317F9652CAADBBC0F000184D586AAAF2D94C100945D72B" },
+  { name = "gleam_stdlib", version = "0.36.0", build_tools = ["gleam"], requirements = [], otp_app = "gleam_stdlib", source = "hex", outer_checksum = "C0D14D807FEC6F8A08A7C9EF8DFDE6AE5C10E40E21325B2B29365965D82EB3D4" },
+  { name = "gleeunit", version = "1.0.2", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleeunit", source = "hex", outer_checksum = "D364C87AFEB26BDB4FB8A5ABDE67D635DC9FA52D6AB68416044C35B096C6882D" },
+  { name = "hackney", version = "1.20.1", build_tools = ["rebar3"], requirements = ["certifi", "idna", "metrics", "mimerl", "parse_trans", "ssl_verify_fun", "unicode_util_compat"], otp_app = "hackney", source = "hex", outer_checksum = "FE9094E5F1A2A2C0A7D10918FEE36BFEC0EC2A979994CFF8CFE8058CD9AF38E3" },
   { name = "idna", version = "6.1.1", build_tools = ["rebar3"], requirements = ["unicode_util_compat"], otp_app = "idna", source = "hex", outer_checksum = "92376EB7894412ED19AC475E4A86F7B413C1B9FBB5BD16DCCD57934157944CEA" },
   { name = "metrics", version = "1.0.1", build_tools = ["rebar3"], requirements = [], otp_app = "metrics", source = "hex", outer_checksum = "69B09ADDDC4F74A40716AE54D140F93BEB0FB8978D8636EADED0C31B6F099F16" },
   { name = "mimerl", version = "1.2.0", build_tools = ["rebar3"], requirements = [], otp_app = "mimerl", source = "hex", outer_checksum = "F278585650AA581986264638EBF698F8BB19DF297F66AD91B18910DFC6E19323" },
@@ -22,7 +22,7 @@ packages = [
 ]
 
 [requirements]
-cowboy = { version = "~> 2.0" }
+cowboy = { version = "~> 2.10.0" }
 gleam_erlang = { version = "~> 0.22" }
 gleam_hackney = { version = "~> 1.0" }
 gleam_http = { version = "~> 3.0" }

--- a/src/gleam_cowboy_native.erl
+++ b/src/gleam_cowboy_native.erl
@@ -1,6 +1,6 @@
 -module(gleam_cowboy_native).
 
--export([init/2, start_link/2, read_entire_body/1]).
+-export([init/2, start_link/2, read_entire_body/1, set_headers/2]).
 
 start_link(Handler, Port) ->
     RanchOptions = #{
@@ -29,3 +29,6 @@ read_entire_body(Body, Req0) ->
         {ok, Chunk, Req1} -> {list_to_binary([Body, Chunk]), Req1};
         {more, Chunk, Req1} -> read_entire_body([Body, Chunk], Req1)
     end.
+
+set_headers(Headers, Req) ->
+  Req#{resp_headers => Headers}.


### PR DESCRIPTION
This PR contains the necessary fixes to have `gleam_cowboy` work with gleam v1.0.0.

In particular it changes:
* replace `gleam/map` with `gleam/list`
* replace `gleam/bit_builder` with `gleam/bytes_builder`
* lock `cowboy` to `2.10` due to some changes with the management of cookie headers in the cowboy library. I wasn't able to figure out how to allow for `cowboy` > 2.0 but < 2.11, so let me know if there's a better way to do this!

I've also updated the example in the README reflect these changes.

Let me know what you think!

Resolves: https://github.com/gleam-lang/cowboy/issues/19 
