### PR TITLE
Updates README example to use `bytes_tree`

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,12 +17,12 @@ import gleam/erlang/process
 import gleam/http/cowboy
 import gleam/http/response.{type Response}
 import gleam/http/request.{type Request}
-import gleam/bytes_builder.{type BytesBuilder}
+import gleam/bytes_tree.{type BytesTree}
 
 // Define a HTTP service
 //
-pub fn my_service(request: Request(t)) -> Response(BytesBuilder) {
-  let body = bytes_builder.from_string("Hello, world!")
+pub fn my_service(request: Request(t)) -> Response(BytesTree) {
+  let body = bytes_tree.from_string("Hello, world!")
 
   response.new(200)
   |> response.prepend_header("made-with", "Gleam")


### PR DESCRIPTION
Updates the README example to use `bytes_tree` over the depreciated `bytes_builder` (as of `gleam_stdlib` v0.42.0).